### PR TITLE
test: exclude unnecessary files from coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,11 @@
     "@types/styled-components": "^5.1.25",
     "cypress": "^10.1.0",
     "husky": "^8.0.0"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "!src/index.tsx",
+      "!src/reportWebVitals.ts"
+    ]
   }
 }


### PR DESCRIPTION
Excludes the following files from the coverage report:
- `src/index.tsx`
- `src/reportWebVitals.ts`