### PR TITLE
test: add defaults to `collectCoverageFrom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   },
   "jest": {
     "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!src/**/*.d.ts",
       "!src/index.tsx",
       "!src/reportWebVitals.ts"
     ]


### PR DESCRIPTION
Followup since #21 got closed too early.

This PR adds the missing defaults from here:
https://github.com/facebook/create-react-app/blob/63bba07d584a769cfaf7699e0aab92ed99c3c57e/packages/react-scripts/scripts/utils/createJestConfig.js#L28