### PR TITLE
fix: only show dropdown scrollbars in case of an overflow

### DIFF
--- a/src/components/TextLabel.tsx
+++ b/src/components/TextLabel.tsx
@@ -86,7 +86,7 @@ interface DropdownOptionsProps {
 const DropdownOptions = styled.div<DropdownOptionsProps>`
   display: ${({ $isOpen }) => ($isOpen ? "grid" : "none")};
   position: absolute;
-  overflow: scroll;
+  overflow: auto;
   grid-area: options;
   grid-template-rows: repeat(
     auto-fit,


### PR DESCRIPTION
set CSS property 'overflow' to 'auto'